### PR TITLE
feat: externalize configuration to config.json (#3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 data.json
+config.json
 score_cache.json
 diffstat_cache.json
 enrich_cache.json
@@ -7,3 +8,4 @@ history.json
 __pycache__/
 .DS_Store
 .local/
+.dollhousemcp/

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,127 @@
+{
+  "repos": {
+    "scan_dirs": [],
+    "broad_scan": {
+      "root": "~/Developer",
+      "max_depth": 4
+    },
+    "skip_patterns": [
+      "/archive/",
+      "/backup/",
+      "node_modules",
+      ".Trash",
+      "singing-clock",
+      "singing-clock-public"
+    ]
+  },
+  "goal": {
+    "name": "Self-sufficient AI system",
+    "inception_date": "2025-06-30"
+  },
+  "scoring": {
+    "large_source_threshold": 100,
+    "medium_source_threshold": 30,
+    "large_source_bonus": 0.30,
+    "medium_source_bonus": 0.15,
+    "major_new_files_threshold": 3,
+    "minor_new_files_threshold": 1,
+    "major_new_files_bonus": 0.20,
+    "minor_new_files_bonus": 0.10,
+    "config_only_multiplier": 0.8,
+    "deletion_heavy_threshold": 50,
+    "deletion_heavy_multiplier": 0.85,
+    "multiplier_floor": 0.4,
+    "multiplier_ceiling": 2.0,
+    "test_lines_threshold": 10,
+    "test_safety_bonus": 2
+  },
+  "rubric": {
+    "categories": {
+      "foundation": {
+        "weight": 1,
+        "patterns": [
+          "initial commit", "setup", "scaffold", "boilerplate",
+          "package\\.json", "tsconfig", "eslint", "prettier",
+          "basic.*structure", "foundation", "directory structure"
+        ]
+      },
+      "elements": {
+        "weight": 2,
+        "patterns": [
+          "persona", "skill", "template", "memory", "element type",
+          "element.*system", "crud", "create.*element", "edit.*element",
+          "delete.*element", "list.*element", "get.*element",
+          "element.*manager", "element.*handler", "element.*storage",
+          "element.*validator", "element.*loader"
+        ]
+      },
+      "agents": {
+        "weight": 3,
+        "patterns": [
+          "agent", "execute", "execution", "autonomy", "autonomous",
+          "agentic", "goal", "objective", "step", "execution.*state",
+          "execution.*lifecycle", "complete.*execution", "continue.*execution",
+          "update.*execution", "agent.*loop", "budget"
+        ]
+      },
+      "self_modify": {
+        "weight": 5,
+        "patterns": [
+          "self.?modif", "self.?improv", "self.?evolv", "self.?updat",
+          "dynamic.*creat", "runtime.*creat", "programmatic.*creat",
+          "auto.?generat", "element.*creat.*element", "meta.?element",
+          "create.*from.*template", "derive", "compose",
+          "addentry", "add.*entry", "append.*memory",
+          "evolv", "adapt", "learn"
+        ]
+      },
+      "meta": {
+        "weight": 5,
+        "patterns": [
+          "introspect", "relationship", "find.*similar", "search.*by.*verb",
+          "relationship.*stats", "element.*relationship", "dependency",
+          "self.?aware", "meta.?cogni", "reflect", "reason.*about",
+          "ensemble", "compose", "orchestrat",
+          "active.*element", "render", "context.*build"
+        ]
+      },
+      "ecosystem": {
+        "weight": 3,
+        "patterns": [
+          "collection", "portfolio", "install", "import",
+          "marketplace", "catalog", "browse", "search.*collection",
+          "submit", "publish", "share", "github.*auth",
+          "sync.*portfolio", "portfolio.*element"
+        ]
+      },
+      "safety": {
+        "weight": 2,
+        "patterns": [
+          "safety", "trust", "operator", "security", "permission",
+          "validation", "sanitiz", "escape", "guard", "tier",
+          "safety.*tier", "operator.*safety", "secure"
+        ]
+      },
+      "integration": {
+        "weight": 2,
+        "patterns": [
+          "ide", "studio", "electron", "bridge",
+          "api.*endpoint", "rest.*api", "websocket", "stream",
+          "external", "connect", "oauth", "zulip",
+          "ci.?cd", "deploy", "docker"
+        ]
+      },
+      "aql": {
+        "weight": 4,
+        "patterns": [
+          "aql", "query.*language", "query.*element", "search.*element",
+          "filter", "narrow", "resolver", "disambigu",
+          "mcp.*tool", "tool.*registr", "tool.*handler",
+          "crude", "operation.*dispatch"
+        ]
+      }
+    },
+    "high_level_categories": ["agents", "self_modify", "meta", "aql"],
+    "low_level_categories": ["foundation", "elements", "integration"]
+  }
+}

--- a/scan.py
+++ b/scan.py
@@ -27,6 +27,10 @@ from pathlib import Path
 
 # ─── Configuration ───────────────────────────────────────────────────────
 
+CONFIG_FILE = Path(__file__).parent / "config.json"
+CONFIG_EXAMPLE = Path(__file__).parent / "config.example.json"
+
+# Defaults (used when no config.json exists)
 INCEPTION_DATE = "2025-06-30"
 DEVELOPER_DIR = Path.home() / "Developer"
 
@@ -90,6 +94,100 @@ MULTIPLIER_FLOOR = 0.4
 MULTIPLIER_CEILING = 2.0
 TEST_LINES_THRESHOLD = 10     # test lines added to trigger safety bonus
 TEST_SAFETY_BONUS = 2
+
+
+# ─── Config File Loading ─────────────────────────────────────────────────
+
+def load_config():
+    """Load configuration from config.json, falling back to built-in defaults.
+
+    Returns the parsed config dict, or None if no config file exists.
+    On parse error, prints a warning and returns None (uses defaults).
+    """
+    if not CONFIG_FILE.exists():
+        return None
+    try:
+        data = json.loads(CONFIG_FILE.read_text())
+        if not isinstance(data, dict):
+            print(f"  Warning: config.json is not a JSON object, using defaults")
+            return None
+        return data
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"  Warning: config.json could not be loaded ({e}), using defaults")
+        return None
+
+
+def apply_config(config):
+    """Apply a loaded config dict to the module-level constants.
+
+    Only overrides values that are present in the config. Missing keys
+    keep the built-in defaults. This function mutates module globals.
+    """
+    global INCEPTION_DATE, SCAN_DIRS, BROAD_SCAN_DIR, BROAD_SCAN_MAX_DEPTH
+    global SKIP_PATTERNS, CATEGORIES, HIGH_LEVEL_CATS, LOW_LEVEL_CATS
+    global LARGE_SOURCE_THRESHOLD, MEDIUM_SOURCE_THRESHOLD
+    global LARGE_SOURCE_BONUS, MEDIUM_SOURCE_BONUS
+    global MAJOR_NEW_FILES_THRESHOLD, MINOR_NEW_FILES_THRESHOLD
+    global MAJOR_NEW_FILES_BONUS, MINOR_NEW_FILES_BONUS
+    global CONFIG_ONLY_MULTIPLIER, DELETION_HEAVY_THRESHOLD
+    global DELETION_HEAVY_MULTIPLIER, MULTIPLIER_FLOOR, MULTIPLIER_CEILING
+    global TEST_LINES_THRESHOLD, TEST_SAFETY_BONUS
+
+    if not config:
+        return
+
+    # Goal settings
+    goal = config.get("goal", {})
+    if "inception_date" in goal:
+        INCEPTION_DATE = goal["inception_date"]
+
+    # Repo settings
+    repos = config.get("repos", {})
+    if "scan_dirs" in repos:
+        SCAN_DIRS = [Path(os.path.expanduser(d)) for d in repos["scan_dirs"]]
+    broad = repos.get("broad_scan", {})
+    if "root" in broad:
+        BROAD_SCAN_DIR = Path(os.path.expanduser(broad["root"]))
+    if "max_depth" in broad:
+        BROAD_SCAN_MAX_DEPTH = int(broad["max_depth"])
+    if "skip_patterns" in repos:
+        SKIP_PATTERNS = repos["skip_patterns"]
+
+    # Scoring thresholds
+    scoring = config.get("scoring", {})
+    if scoring:
+        LARGE_SOURCE_THRESHOLD = scoring.get("large_source_threshold", LARGE_SOURCE_THRESHOLD)
+        MEDIUM_SOURCE_THRESHOLD = scoring.get("medium_source_threshold", MEDIUM_SOURCE_THRESHOLD)
+        LARGE_SOURCE_BONUS = scoring.get("large_source_bonus", LARGE_SOURCE_BONUS)
+        MEDIUM_SOURCE_BONUS = scoring.get("medium_source_bonus", MEDIUM_SOURCE_BONUS)
+        MAJOR_NEW_FILES_THRESHOLD = scoring.get("major_new_files_threshold", MAJOR_NEW_FILES_THRESHOLD)
+        MINOR_NEW_FILES_THRESHOLD = scoring.get("minor_new_files_threshold", MINOR_NEW_FILES_THRESHOLD)
+        MAJOR_NEW_FILES_BONUS = scoring.get("major_new_files_bonus", MAJOR_NEW_FILES_BONUS)
+        MINOR_NEW_FILES_BONUS = scoring.get("minor_new_files_bonus", MINOR_NEW_FILES_BONUS)
+        CONFIG_ONLY_MULTIPLIER = scoring.get("config_only_multiplier", CONFIG_ONLY_MULTIPLIER)
+        DELETION_HEAVY_THRESHOLD = scoring.get("deletion_heavy_threshold", DELETION_HEAVY_THRESHOLD)
+        DELETION_HEAVY_MULTIPLIER = scoring.get("deletion_heavy_multiplier", DELETION_HEAVY_MULTIPLIER)
+        MULTIPLIER_FLOOR = scoring.get("multiplier_floor", MULTIPLIER_FLOOR)
+        MULTIPLIER_CEILING = scoring.get("multiplier_ceiling", MULTIPLIER_CEILING)
+        TEST_LINES_THRESHOLD = scoring.get("test_lines_threshold", TEST_LINES_THRESHOLD)
+        TEST_SAFETY_BONUS = scoring.get("test_safety_bonus", TEST_SAFETY_BONUS)
+
+    # Rubric (category definitions)
+    rubric = config.get("rubric", {})
+    if "categories" in rubric:
+        CATEGORIES.clear()
+        for cat_name, cat_def in rubric["categories"].items():
+            CATEGORIES[cat_name] = {
+                "weight": cat_def.get("weight", 1),
+                "patterns": cat_def.get("patterns", []),
+            }
+        # Recompile regex patterns
+        for cat in CATEGORIES.values():
+            cat["compiled"] = [re.compile(p) for p in cat["patterns"]]
+    if "high_level_categories" in rubric:
+        HIGH_LEVEL_CATS = set(rubric["high_level_categories"])
+    if "low_level_categories" in rubric:
+        LOW_LEVEL_CATS = set(rubric["low_level_categories"])
 
 
 # ─── Capability Scoring Rubric ───────────────────────────────────────────
@@ -989,6 +1087,17 @@ def main(args=None):
     print("=" * 60)
     print("Singing Clock - Scanning repositories...")
     print("=" * 60)
+
+    # Load configuration
+    config = load_config()
+    if config:
+        print(f"\n  Loaded configuration from {CONFIG_FILE.name}")
+        apply_config(config)
+    elif not CONFIG_FILE.exists() and CONFIG_EXAMPLE.exists():
+        print(f"\n  No config.json found. Using built-in defaults.")
+        print(f"  To customize, copy config.example.json to config.json:")
+        print(f"    cp config.example.json config.json")
+        print(f"  Then edit config.json with your repo paths and preferences.")
 
     # Discover repos
     print("\nDiscovering repositories...")


### PR DESCRIPTION
## Summary
Adds config.json support so users can configure Singing Clock without editing Python source code. This is the HIGH PRIORITY configuration externalization.

Closes #3

## Changes
- **config.example.json** — Complete template with all configurable values: repo paths, skip patterns, scoring thresholds, rubric categories, and goal settings
- **scan.py** — Added `load_config()` and `apply_config()` functions that read config.json and override module defaults. First-run message guides new users
- **.gitignore** — Added config.json and .dollhousemcp/

## What's configurable
- `repos.scan_dirs` — directories to scan
- `repos.broad_scan.root` and `max_depth` — broad scan settings
- `repos.skip_patterns` — paths to exclude
- `goal.inception_date` — project start date
- `scoring.*` — all diffstat thresholds and multipliers
- `rubric.categories` — full category definitions with weights and patterns
- `rubric.high_level_categories` / `low_level_categories` — sophistication groupings

## Backwards compatibility
When no config.json exists, behavior is identical to before — all built-in defaults are preserved. The config is purely additive.

## Testing
```bash
# Verify import works
python3 -c "import scan; print('OK')"

# Test with config
cp config.example.json config.json
# Edit config.json with your repos
python3 scan.py
```

## Checklist
- [x] Branch created from develop
- [x] Changes focused on single issue
- [x] No cache or data files committed
- [x] config.json added to .gitignore
- [x] Full backwards compatibility maintained