### PR TITLE
Improve error handling and scan failure feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -232,6 +232,36 @@
     font-size: 1.2rem;
   }
 
+  .scan-error-details {
+    max-width: 800px;
+    margin: 1rem auto 0;
+    text-align: left;
+  }
+
+  .scan-error-details summary {
+    cursor: pointer;
+    color: var(--text-dim);
+    font-size: 0.75rem;
+    text-align: center;
+    padding: 0.5rem;
+  }
+
+  .scan-error-details summary:hover { color: var(--text); }
+
+  .scan-log-output {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 1rem;
+    margin-top: 0.5rem;
+    font-size: 0.7rem;
+    color: var(--text-dim);
+    max-height: 300px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
   @media (max-width: 900px) {
     .charts { grid-template-columns: 1fr; }
     .countdown { font-size: 3rem; }
@@ -443,21 +473,35 @@ async function pollForCompletion() {
 
   const interval = setInterval(async () => {
     try {
-      // Check if data.json has been updated
-      const resp = await fetch('data.json?t=' + Date.now());
-      if (resp.ok) {
-        const newData = await resp.json();
-        if (newData.generated !== origGenerated) {
-          clearInterval(interval);
-          status.className = 'scan-status done';
-          status.textContent = `Scan complete! Updated ${new Date(newData.generated).toLocaleTimeString()}`;
-          btn.disabled = false;
-          // Reload page to show new data
-          setTimeout(() => location.reload(), 500);
-          return;
+      const statusResp = await fetch('/api/status');
+      if (statusResp.ok) {
+        const st = await statusResp.json();
+
+        // Scan finished — check result
+        if (!st.scan_running) {
+          // Check if data.json was updated
+          const dataResp = await fetch('data.json?t=' + Date.now());
+          if (dataResp.ok) {
+            const newData = await dataResp.json();
+            if (newData.generated !== origGenerated) {
+              clearInterval(interval);
+              status.className = 'scan-status done';
+              status.textContent = `Scan complete! Updated ${new Date(newData.generated).toLocaleTimeString()}`;
+              btn.disabled = false;
+              setTimeout(() => location.reload(), 500);
+              return;
+            }
+          }
+
+          // Scan stopped but data didn't update — likely a failure
+          if (st.last_scan_success === false) {
+            clearInterval(interval);
+            await showScanFailure(status, btn);
+            return;
+          }
         }
       }
-    } catch (e) { /* ignore */ }
+    } catch (e) { /* keep polling */ }
 
     // Timeout after 5 minutes
     if (Date.now() - startTime > 300000) {
@@ -465,16 +509,67 @@ async function pollForCompletion() {
       status.className = 'scan-status error';
       status.textContent = 'Scan timed out';
       btn.disabled = false;
+      await showScanLogs();
     }
   }, 2000);
 }
 
+async function showScanFailure(statusEl, btn) {
+  statusEl.className = 'scan-status error';
+  statusEl.textContent = 'Scan failed.';
+  btn.disabled = false;
+  btn.textContent = 'Retry Scan';
+  await showScanLogs();
+}
+
+async function showScanLogs() {
+  try {
+    const resp = await fetch('/api/scan-logs');
+    if (!resp.ok) return;
+    const logs = await resp.json();
+    if (!logs.output) return;
+
+    // Remove existing log details if any
+    const existing = document.querySelector('.scan-error-details');
+    if (existing) existing.remove();
+
+    const details = document.createElement('details');
+    details.className = 'scan-error-details';
+    details.innerHTML = `<summary>View scan logs</summary>` +
+      `<pre class="scan-log-output">${escapeHtml(logs.output)}</pre>`;
+
+    const controls = document.querySelector('.controls');
+    controls.parentNode.insertBefore(details, controls.nextSibling);
+  } catch (_) { /* no logs available */ }
+}
+
+function escapeHtml(str) {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
 // ─── Data Loading ───────────────────────────────────────────────────────
+function validateData(data) {
+  const issues = [];
+  if (!data || typeof data !== 'object') return ['data.json is not a valid object'];
+  if (!data.generated) issues.push('missing "generated" timestamp');
+  if (!data.months || !Array.isArray(data.months)) issues.push('missing "months" array');
+  if (!data.current || typeof data.current !== 'object') issues.push('missing "current" stats');
+  return issues;
+}
+
 async function loadData() {
   try {
     const resp = await fetch('data.json');
     if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-    return await resp.json();
+    const data = await resp.json();
+    const issues = validateData(data);
+    if (issues.length > 0) {
+      console.warn('data.json validation:', issues);
+      // Partial data — still return it so we can render what we have
+      data._partial = true;
+      data._validationIssues = issues;
+    }
+    return data;
   } catch (e) {
     document.querySelector('.hero').innerHTML = `
       <div class="error">
@@ -984,16 +1079,26 @@ async function init() {
     fill.textContent = `${pct.toFixed(1)}%`;
   }, 100);
 
-  // Charts
-  renderDriftChart(data);
-  renderCommitChart(data);
-  renderCapabilityChart(data);
-  renderSophisticationChart(data);
-  renderConvergenceChart(data);
+  // Charts — wrap each in try/catch so partial data doesn't break everything
+  try { renderDriftChart(data); } catch (e) { console.warn('Drift chart error:', e); }
+  try { renderCommitChart(data); } catch (e) { console.warn('Commit chart error:', e); }
+  try { renderCapabilityChart(data); } catch (e) { console.warn('Capability chart error:', e); }
+  try { renderSophisticationChart(data); } catch (e) { console.warn('Sophistication chart error:', e); }
+  try { renderConvergenceChart(data); } catch (e) { console.warn('Convergence chart error:', e); }
 
   // Footer
-  document.getElementById('footer').textContent =
-    `Last scan: ${data.generated} | ${data.repos_scanned} repos | ${data.total_commits.toLocaleString()} commits | Inception: ${data.inception_date}`;
+  const footer = document.getElementById('footer');
+  const parts = [];
+  if (data.generated) parts.push(`Last scan: ${data.generated}`);
+  if (data.repos_scanned) parts.push(`${data.repos_scanned} repos`);
+  if (data.total_commits) parts.push(`${data.total_commits.toLocaleString()} commits`);
+  if (data.inception_date) parts.push(`Inception: ${data.inception_date}`);
+  footer.textContent = parts.join(' | ') || 'No scan data available';
+
+  // Show warning banner for partial data
+  if (data._partial) {
+    footer.textContent += ' (partial data — some fields missing)';
+  }
 }
 
 init();

--- a/server.py
+++ b/server.py
@@ -9,18 +9,24 @@ Default port: 8080
 
 import http.server
 import json
-import os
 import subprocess
 import sys
 import threading
 from pathlib import Path
 
+from datetime import datetime, timezone
+
 PORT = int(sys.argv[1]) if len(sys.argv) > 1 else 8080
 PROJECT_DIR = Path(__file__).parent
+
+
+def _now_iso():
+    return datetime.now(timezone.utc).isoformat()
 
 # Track scan state
 scan_lock = threading.Lock()
 scan_running = False
+last_scan_result = {"success": None, "output": "", "timestamp": None}
 
 
 class Handler(http.server.SimpleHTTPRequestHandler):
@@ -32,11 +38,19 @@ class Handler(http.server.SimpleHTTPRequestHandler):
             self.handle_scan()
         elif self.path == "/api/status":
             self.handle_status()
+        elif self.path == "/api/scan-logs":
+            self.handle_scan_logs()
         elif self.path == "/":
             self.path = "/index.html"
             super().do_GET()
         else:
             super().do_GET()
+
+    def do_POST(self):
+        if self.path == "/api/scan":
+            self.handle_scan()
+        else:
+            self.send_error(405, "Method not allowed")
 
     def handle_scan(self):
         global scan_running
@@ -45,7 +59,7 @@ class Handler(http.server.SimpleHTTPRequestHandler):
             return
 
         def run_scan():
-            global scan_running
+            global scan_running, last_scan_result
             scan_running = True
             try:
                 result = subprocess.run(
@@ -53,9 +67,28 @@ class Handler(http.server.SimpleHTTPRequestHandler):
                     capture_output=True, text=True, timeout=300,
                     cwd=str(PROJECT_DIR),
                 )
-                return result.returncode == 0, result.stdout + result.stderr
+                output = result.stdout + result.stderr
+                success = result.returncode == 0
+                last_scan_result = {
+                    "success": success,
+                    "output": output[-10000:],  # keep last 10K chars
+                    "timestamp": _now_iso(),
+                    "returncode": result.returncode,
+                }
+            except subprocess.TimeoutExpired:
+                last_scan_result = {
+                    "success": False,
+                    "output": "Scan timed out after 5 minutes",
+                    "timestamp": _now_iso(),
+                    "returncode": -1,
+                }
             except Exception as e:
-                return False, str(e)
+                last_scan_result = {
+                    "success": False,
+                    "output": str(e),
+                    "timestamp": _now_iso(),
+                    "returncode": -1,
+                }
             finally:
                 scan_running = False
 
@@ -66,20 +99,32 @@ class Handler(http.server.SimpleHTTPRequestHandler):
         thread.start()
 
     def handle_status(self):
+        global last_scan_result
+        status = {"scan_running": scan_running, "status": "running" if scan_running else "idle"}
         data_file = PROJECT_DIR / "data.json"
         if data_file.exists():
             try:
                 with open(data_file) as f:
                     d = json.load(f)
-                self.send_json({
-                    "scan_running": scan_running,
-                    "last_scan": d.get("generated"),
-                    "total_commits": d.get("total_commits"),
-                })
+                status["last_scan"] = d.get("generated")
+                status["total_commits"] = d.get("total_commits")
+                status["repos_scanned"] = d.get("repos_scanned")
             except Exception:
-                self.send_json({"scan_running": scan_running, "last_scan": None})
+                status["last_scan"] = None
         else:
-            self.send_json({"scan_running": scan_running, "last_scan": None})
+            status["last_scan"] = None
+        if last_scan_result["success"] is not None:
+            status["last_scan_success"] = last_scan_result["success"]
+            status["last_scan_timestamp"] = last_scan_result["timestamp"]
+        self.send_json(status)
+
+    def handle_scan_logs(self):
+        self.send_json({
+            "success": last_scan_result["success"],
+            "output": last_scan_result["output"],
+            "timestamp": last_scan_result["timestamp"],
+            "scan_running": scan_running,
+        })
 
     def send_json(self, data, code=200):
         self.send_response(code)


### PR DESCRIPTION
## Summary
- Adds `/api/scan-logs` endpoint returning last scan stdout/stderr for debugging
- Stores scan results (output, success, timestamp) in server memory
- Adds POST handler for `/api/scan` (previously GET-only)
- Polls `/api/status` for smarter scan completion detection (checks `last_scan_success`)
- Shows "Retry Scan" button and expandable scan logs panel on failures
- Validates data.json structure before rendering; gracefully handles partial data
- Each chart render is individually wrapped in try/catch — one broken chart won't take down the whole dashboard
- Footer builds dynamically from available fields instead of crashing on missing data

## Test plan
- [ ] Trigger scan with valid config — verify normal flow still works
- [ ] Trigger scan with no repos configured — verify failure shows logs
- [ ] Visit `/api/scan-logs` directly — verify JSON response
- [ ] Visit `/api/status` — verify includes `last_scan_success` field
- [ ] Manually corrupt data.json — verify dashboard degrades gracefully
- [ ] Remove data.json — verify error message displays

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)