### PR TITLE
Fix ClaudeBot review workflow permissions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:


### PR DESCRIPTION
## Summary
- Changes `pull-requests` permission from `read` to `write` in `claude-code-review.yml`
- Changes `issues` permission from `read` to `write`
- This allows ClaudeBot to post actual review comments on PRs instead of only running pass/fail CI checks

## Context
All 6 PRs merged today passed ClaudeBot CI checks but received no review comments because the workflow lacked write permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)