### PR TITLE
Revert workflow permissions to read-only

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
-      issues: write
+      pull-requests: read
+      issues: read
       id-token: write
 
     steps:


### PR DESCRIPTION
## Summary
Reverts the permission change from PR #23 (`pull-requests: write` back to `read`).

## Why
- The `claude-code-action` uses its own OAuth token for GitHub API calls, not `GITHUB_TOKEN`
- Workflow permissions don't control whether ClaudeBot posts review comments
- The real reason reviews weren't appearing: workflow file mismatch between PR branch and `main` (default branch)
- **Fix**: Sync `main` with `develop` so the workflow file validation passes
- Read-only is the safer default for fork PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)