### PR TITLE
Enhance history tracking with scoring method, model stats, and dedup

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -849,16 +849,22 @@ def load_history():
     return []
 
 
-def record_history(models, current):
-    """Append a snapshot to history.json and return the full history."""
+def record_history(models, current, scoring_method="regex"):
+    """Append a snapshot to history.json and return the full history.
+
+    Deduplicates entries: skips append if the previous entry has the same
+    convergence_date and total_commits (i.e. nothing changed).
+    """
     history = load_history()
+    cap_model = models.get("capability", {})
     entry = {
         "scan_time": datetime.datetime.now().isoformat(timespec="seconds"),
+        "scoring_method": scoring_method,
         "convergence_date": models.get("convergence_date"),
         "component_dates": {
             "commit_zero": models.get("commit_rate", {}).get("zero_date"),
-            "capability_95": models.get("capability", {}).get("pct_95_date"),
-            "capability_99": models.get("capability", {}).get("pct_99_date"),
+            "capability_95": cap_model.get("pct_95_date"),
+            "capability_99": cap_model.get("pct_99_date"),
             "sophistication_100": models.get("sophistication", {}).get("pct_100_date"),
         },
         "days_until_convergence": (
@@ -866,8 +872,21 @@ def record_history(models, current):
             if models.get("convergence_date") else None
         ),
         "total_commits": current.get("total_commits", 0),
+        "total_capability": current.get("total_capability", 0),
         "pct_of_asymptote": current.get("pct_of_asymptote", 0),
+        "capability_L": cap_model.get("L"),
+        "capability_r2": cap_model.get("r_squared"),
+        "commit_rate_r2": models.get("commit_rate", {}).get("r_squared"),
     }
+
+    # Deduplicate: skip if same convergence_date + total_commits as last entry
+    if history:
+        prev = history[-1]
+        if (prev.get("convergence_date") == entry["convergence_date"]
+                and prev.get("total_commits") == entry["total_commits"]):
+            print(f"  History unchanged (same convergence date + commits), skipping")
+            return history
+
     history.append(entry)
     try:
         HISTORY_FILE.write_text(json.dumps(history, indent=2))
@@ -1306,7 +1325,8 @@ def main(args=None):
 
     # Record history
     print("\nRecording convergence history...")
-    convergence_history = record_history(models, current)
+    scoring_method = f"llm_{args['enrich_model']}" if args.get("enrich") else "regex"
+    convergence_history = record_history(models, current, scoring_method)
 
     # Build output
     output = {

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,169 @@
+"""Tests for history tracking with enhanced schema and deduplication."""
+
+import json
+import tempfile
+import unittest
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import scan
+
+
+class TestRecordHistory(unittest.TestCase):
+    """Tests for record_history() — enhanced history entries."""
+
+    def _make_models(self, convergence_date="2026-06-15"):
+        return {
+            "convergence_date": convergence_date,
+            "commit_rate": {"zero_date": "2026-07-01", "r_squared": 0.85},
+            "capability": {
+                "pct_95_date": "2026-05-01",
+                "pct_99_date": "2026-06-01",
+                "L": 350,
+                "r_squared": 0.92,
+            },
+            "sophistication": {"pct_100_date": "2026-08-01"},
+        }
+
+    def _make_current(self, total_commits=150):
+        return {
+            "total_commits": total_commits,
+            "total_capability": 230,
+            "pct_of_asymptote": 65.7,
+        }
+
+    def test_records_entry(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write("[]")
+            tmp = Path(f.name)
+        try:
+            with patch.object(scan, "HISTORY_FILE", tmp):
+                history = scan.record_history(
+                    self._make_models(), self._make_current()
+                )
+            self.assertEqual(len(history), 1)
+            entry = history[0]
+            self.assertEqual(entry["convergence_date"], "2026-06-15")
+            self.assertEqual(entry["total_commits"], 150)
+        finally:
+            tmp.unlink()
+
+    def test_scoring_method_default(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write("[]")
+            tmp = Path(f.name)
+        try:
+            with patch.object(scan, "HISTORY_FILE", tmp):
+                history = scan.record_history(
+                    self._make_models(), self._make_current()
+                )
+            self.assertEqual(history[0]["scoring_method"], "regex")
+        finally:
+            tmp.unlink()
+
+    def test_scoring_method_llm(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write("[]")
+            tmp = Path(f.name)
+        try:
+            with patch.object(scan, "HISTORY_FILE", tmp):
+                history = scan.record_history(
+                    self._make_models(), self._make_current(), "llm_haiku"
+                )
+            self.assertEqual(history[0]["scoring_method"], "llm_haiku")
+        finally:
+            tmp.unlink()
+
+    def test_enhanced_fields_present(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write("[]")
+            tmp = Path(f.name)
+        try:
+            with patch.object(scan, "HISTORY_FILE", tmp):
+                history = scan.record_history(
+                    self._make_models(), self._make_current()
+                )
+            entry = history[0]
+            self.assertEqual(entry["total_capability"], 230)
+            self.assertEqual(entry["capability_L"], 350)
+            self.assertAlmostEqual(entry["capability_r2"], 0.92)
+            self.assertAlmostEqual(entry["commit_rate_r2"], 0.85)
+        finally:
+            tmp.unlink()
+
+    def test_deduplication_skips_identical(self):
+        prev_entry = {
+            "convergence_date": "2026-06-15",
+            "total_commits": 150,
+        }
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump([prev_entry], f)
+            tmp = Path(f.name)
+        try:
+            with patch.object(scan, "HISTORY_FILE", tmp):
+                history = scan.record_history(
+                    self._make_models(), self._make_current()
+                )
+            # Should not append — same convergence_date and total_commits
+            self.assertEqual(len(history), 1)
+        finally:
+            tmp.unlink()
+
+    def test_deduplication_allows_different_commits(self):
+        prev_entry = {
+            "convergence_date": "2026-06-15",
+            "total_commits": 100,  # different from 150
+        }
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump([prev_entry], f)
+            tmp = Path(f.name)
+        try:
+            with patch.object(scan, "HISTORY_FILE", tmp):
+                history = scan.record_history(
+                    self._make_models(), self._make_current()
+                )
+            # Should append — different total_commits
+            self.assertEqual(len(history), 2)
+        finally:
+            tmp.unlink()
+
+    def test_deduplication_allows_different_date(self):
+        prev_entry = {
+            "convergence_date": "2026-07-01",  # different date
+            "total_commits": 150,
+        }
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump([prev_entry], f)
+            tmp = Path(f.name)
+        try:
+            with patch.object(scan, "HISTORY_FILE", tmp):
+                history = scan.record_history(
+                    self._make_models(), self._make_current()
+                )
+            # Should append — different convergence_date
+            self.assertEqual(len(history), 2)
+        finally:
+            tmp.unlink()
+
+    def test_component_dates(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write("[]")
+            tmp = Path(f.name)
+        try:
+            with patch.object(scan, "HISTORY_FILE", tmp):
+                history = scan.record_history(
+                    self._make_models(), self._make_current()
+                )
+            dates = history[0]["component_dates"]
+            self.assertEqual(dates["commit_zero"], "2026-07-01")
+            self.assertEqual(dates["capability_95"], "2026-05-01")
+            self.assertEqual(dates["capability_99"], "2026-06-01")
+            self.assertEqual(dates["sophistication_100"], "2026-08-01")
+        finally:
+            tmp.unlink()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `scoring_method` field to history entries ("regex" or "llm_haiku"/"llm_sonnet")
- Adds `total_capability`, `capability_L`, `capability_r2`, `commit_rate_r2` for model quality tracking
- Adds deduplication: skips recording when convergence_date + total_commits match previous entry
- 8 new unit tests in `tests/test_history.py`

## Test plan
- [x] All 150 tests pass (142 existing + 8 new)
- [x] Default scoring_method is "regex"
- [x] LLM scoring method correctly recorded
- [x] Enhanced fields (total_capability, capability_L, r2 values) present in entries
- [x] Dedup skips identical entries, allows different commits or dates
- [x] Component dates properly extracted from models

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)