### PR TITLE
feat: score open issues by projected convergence impact

### DIFF
--- a/index.html
+++ b/index.html
@@ -357,6 +357,50 @@
   .scoring-toggle .swatch-enriched { background: var(--teal); }
   .scoring-toggle .swatch-regex { background: var(--yellow); border-style: dashed; }
 
+  .issue-impact-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.8rem;
+  }
+
+  .issue-impact-table th {
+    text-align: left;
+    padding: 0.5rem 0.75rem;
+    color: var(--text-dim);
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border-bottom: 1px solid var(--border);
+    white-space: nowrap;
+  }
+
+  .issue-impact-table td {
+    padding: 0.5rem 0.75rem;
+    border-bottom: 1px solid var(--border);
+    color: var(--text);
+    vertical-align: top;
+  }
+
+  .issue-impact-table tr:last-child td { border-bottom: none; }
+
+  .issue-impact-table .rank { color: var(--text-dim); font-weight: 700; width: 2rem; text-align: center; }
+  .issue-impact-table .impact { font-weight: 700; white-space: nowrap; }
+  .issue-impact-table .impact.positive { color: var(--teal); }
+  .issue-impact-table .impact.neutral { color: var(--text-dim); }
+  .issue-impact-table .score { color: var(--yellow); white-space: nowrap; }
+  .issue-impact-table .issue-title { max-width: 400px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .issue-impact-table .repo-name { color: var(--text-dim); font-size: 0.7rem; }
+  .issue-impact-table .cats { font-size: 0.7rem; color: var(--text-dim); }
+  .issue-impact-table .cat-tag {
+    display: inline-block;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    padding: 0.1rem 0.35rem;
+    margin: 0.1rem;
+    font-size: 0.65rem;
+  }
+
   .scan-status {
     font-size: 0.75rem;
     color: var(--text-dim);
@@ -797,6 +841,14 @@
     <h2>Convergence: Effort vs. Capability</h2>
     <div class="chart-subtitle">Commit rate derivative vs. capability derivative — crossing = graduation</div>
     <div class="chart-container"><canvas id="chart-convergence" role="img" aria-label="Convergence chart comparing effort and capability derivatives"></canvas></div>
+  </div>
+</section>
+
+<section class="issue-impact-section" id="issue-impact-section" style="display:none;" aria-label="Issue convergence impact">
+  <div class="chart-card" style="max-width:1400px; margin:0 auto 1.5rem;">
+    <h2>Open Issues by Convergence Impact</h2>
+    <div class="chart-subtitle">Ranked by estimated days shifted toward graduation if completed</div>
+    <div id="issue-impact-table-wrapper" style="margin-top:1rem; overflow-x:auto;"></div>
   </div>
 </section>
 
@@ -1789,6 +1841,42 @@ function renderDriftChart(data) {
   });
 }
 
+// ─── Issue Impact Table ─────────────────────────────────────────────────
+function renderIssueImpactTable(data) {
+  const issues = data.issue_scores;
+  if (!issues || issues.length === 0) return;
+
+  document.getElementById('issue-impact-section').style.display = 'block';
+  const wrapper = document.getElementById('issue-impact-table-wrapper');
+
+  const rows = issues.map(issue => {
+    const impactClass = issue.convergence_impact_days < 0 ? 'positive' : 'neutral';
+    const impactText = issue.convergence_impact_days < 0
+      ? `${issue.convergence_impact_days}d`
+      : issue.convergence_impact_days === 0 ? '0d' : `+${issue.convergence_impact_days}d`;
+
+    const catTags = Object.keys(issue.categories || {})
+      .map(c => `<span class="cat-tag">${c}</span>`)
+      .join('');
+
+    return `<tr>
+      <td class="rank">${issue.priority_rank}</td>
+      <td class="impact ${impactClass}">${impactText}</td>
+      <td class="score">${issue.projected_score}</td>
+      <td class="issue-title" title="${escapeHtml(issue.title)}">${escapeHtml(issue.title)}</td>
+      <td class="repo-name">${escapeHtml(issue.repo)}#${issue.number}</td>
+      <td class="cats">${catTags}</td>
+    </tr>`;
+  }).join('');
+
+  wrapper.innerHTML = `<table class="issue-impact-table">
+    <thead><tr>
+      <th>#</th><th>Impact</th><th>Score</th><th>Issue</th><th>Repo</th><th>Categories</th>
+    </tr></thead>
+    <tbody>${rows}</tbody>
+  </table>`;
+}
+
 // ─── Dual-Scoring Overlay ────────────────────────────────────────────────
 let chartInstances = {};
 
@@ -1856,6 +1944,7 @@ async function init() {
   try { renderCapabilityChart(data); } catch (e) { console.warn('Capability chart error:', e); }
   try { renderSophisticationChart(data); } catch (e) { console.warn('Sophistication chart error:', e); }
   try { renderConvergenceChart(data); } catch (e) { console.warn('Convergence chart error:', e); }
+  try { renderIssueImpactTable(data); } catch (e) { console.warn('Issue impact table error:', e); }
 
   // Show scoring toggles if dual-scoring data is present
   if (hasDualScoring()) {

--- a/tests/test_issue_scoring.py
+++ b/tests/test_issue_scoring.py
@@ -1,0 +1,111 @@
+"""Tests for issue impact scoring functions."""
+
+import unittest
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from scan import score_issue, estimate_convergence_impact
+
+
+class TestScoreIssue(unittest.TestCase):
+    """Tests for score_issue() — regex scoring of issue title + body."""
+
+    def test_empty_title(self):
+        total, cats = score_issue("")
+        self.assertEqual(total, 0.5)
+        self.assertEqual(cats, {})
+
+    def test_agent_issue(self):
+        total, cats = score_issue("Implement agent execution loop")
+        self.assertIn("agents", cats)
+        self.assertGreater(total, 0.5)
+
+    def test_foundation_issue(self):
+        total, cats = score_issue("Initial setup and scaffold the project structure")
+        self.assertIn("foundation", cats)
+        self.assertGreater(total, 0.5)
+
+    def test_multi_category_issue(self):
+        total, cats = score_issue(
+            "Add self-modify capabilities to the agent execution system",
+            body="This involves creating runtime agent instances with introspect support"
+        )
+        # Should match agents, self_modify, meta
+        self.assertGreater(len(cats), 1)
+        self.assertGreater(total, 3)
+
+    def test_body_contributes_to_score(self):
+        title_only, _ = score_issue("Generic task update")
+        with_body, _ = score_issue(
+            "Generic task update",
+            body="Implement agent execution with self-modify and introspect capabilities"
+        )
+        self.assertGreater(with_body, title_only)
+
+    def test_no_match_gets_floor(self):
+        total, cats = score_issue("Fix typo in readme")
+        self.assertEqual(total, 0.5)
+        self.assertEqual(cats, {})
+
+    def test_safety_issue(self):
+        total, cats = score_issue("Add input validation and security sanitization")
+        self.assertIn("safety", cats)
+
+    def test_ecosystem_issue(self):
+        total, cats = score_issue("Add collection browsing and portfolio sync")
+        self.assertIn("ecosystem", cats)
+
+
+class TestEstimateConvergenceImpact(unittest.TestCase):
+    """Tests for estimate_convergence_impact()."""
+
+    def test_no_model_returns_zero(self):
+        impact = estimate_convergence_impact(10, {})
+        self.assertEqual(impact, 0.0)
+
+    def test_positive_score_negative_impact(self):
+        """Higher score should move convergence closer (negative days)."""
+        models = {
+            "capability": {"L": 1000, "r": 0.6, "t_mid": 5.0, "pct_now": 50.0}
+        }
+        impact = estimate_convergence_impact(20, models)
+        self.assertLess(impact, 0)
+
+    def test_higher_score_more_impact(self):
+        """A higher projected score should have more impact."""
+        models = {
+            "capability": {"L": 1000, "r": 0.6, "t_mid": 5.0, "pct_now": 50.0}
+        }
+        impact_low = estimate_convergence_impact(5, models)
+        impact_high = estimate_convergence_impact(20, models)
+        self.assertLess(impact_high, impact_low)  # more negative = more impact
+
+    def test_near_saturation_more_time_impact(self):
+        """Near saturation, growth is slow so each point saves more days."""
+        models_mid = {
+            "capability": {"L": 1000, "r": 0.6, "t_mid": 5.0, "pct_now": 50.0}
+        }
+        models_high = {
+            "capability": {"L": 1000, "r": 0.6, "t_mid": 5.0, "pct_now": 95.0}
+        }
+        impact_mid = estimate_convergence_impact(10, models_mid)
+        impact_high = estimate_convergence_impact(10, models_high)
+        # Near saturation, growth is slow so same score saves MORE days
+        self.assertLess(impact_high, impact_mid)
+
+    def test_zero_score_zero_impact(self):
+        models = {
+            "capability": {"L": 1000, "r": 0.6, "t_mid": 5.0, "pct_now": 50.0}
+        }
+        impact = estimate_convergence_impact(0, models)
+        self.assertEqual(impact, 0.0)
+
+    def test_missing_L_returns_zero(self):
+        models = {"capability": {"L": 0, "r": 0.6, "t_mid": 5.0, "pct_now": 50.0}}
+        impact = estimate_convergence_impact(10, models)
+        self.assertEqual(impact, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Discovers open GitHub issues via `gh issue list` across all scanned repos
- Scores each issue's title + body against the CATEGORIES rubric (same regex patterns as commit scoring)
- Estimates convergence impact: how many days closer to graduation if the issue were completed
- Outputs ranked `issue_scores` array in data.json
- Dashboard renders a ranked table below charts showing impact, score, categories per issue
- 14 new unit tests for `score_issue()` and `estimate_convergence_impact()`

## Changes
- **scan.py**: Added `discover_open_issues()`, `score_issue()`, `estimate_convergence_impact()`, `score_all_issues()` functions + integration in `main()`
- **index.html**: Issue impact table section with CSS styling, `renderIssueImpactTable()` JS function
- **tests/test_issue_scoring.py**: Tests for scoring, impact estimation, edge cases

## Test plan
- [x] All 185 tests pass
- [x] Dashboard renders issue impact table with mock data
- [x] Table shows rank, impact days, score, title, repo, categories
- [x] Hidden when no issue_scores in data
- [x] No JS console errors

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)