### PR TITLE
Add Docker support and --bind-all server flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 FROM python:3.12-slim
 
 WORKDIR /app
-COPY scan.py server.py index.html config.example.json ./
+COPY *.py *.html *.json ./
+
+RUN useradd -m -u 1000 clockuser && \
+    chown -R clockuser:clockuser /app
+USER clockuser
 
 EXPOSE 8080
 CMD ["python3", "server.py", "--bind-all"]

--- a/server.py
+++ b/server.py
@@ -3,8 +3,9 @@
 Singing Clock - Local Server
 Serves the dashboard and provides a /api/scan endpoint to trigger rescans.
 
-Usage: python3 server.py [port]
+Usage: python3 server.py [port] [--bind-all]
 Default port: 8080
+Default bind: 127.0.0.1 (use --bind-all for 0.0.0.0)
 """
 
 import http.server
@@ -19,7 +20,14 @@ from urllib.parse import urlparse, parse_qs
 from datetime import datetime, timezone
 
 _positional = [a for a in sys.argv[1:] if not a.startswith("--")]
-PORT = int(_positional[0]) if _positional else 8080
+try:
+    PORT = int(_positional[0]) if _positional else 8080
+    if not 1 <= PORT <= 65535:
+        raise ValueError(f"Port must be between 1 and 65535, got {PORT}")
+except (ValueError, IndexError) as e:
+    print(f"Error: {e}", file=sys.stderr)
+    print("Usage: python3 server.py [port] [--bind-all]", file=sys.stderr)
+    sys.exit(1)
 PROJECT_DIR = Path(__file__).parent
 
 


### PR DESCRIPTION
## Summary
- **Dockerfile**: Lightweight `python:3.12-slim` image serving the dashboard on port 8080
- **server.py**: Added `--bind-all` flag to bind `0.0.0.0` (required for Docker containers), default remains `127.0.0.1` for local use
- **server.py**: Fixed argv parsing to skip `--` flags when reading the optional port number

## Usage
```bash
# Build and run
docker build -t singing-clock .
docker run -d -p 8081:8080 singing-clock

# Dashboard at http://localhost:8081
```

## Test plan
- [ ] `docker build -t singing-clock .` succeeds
- [ ] `docker run -d -p 8081:8080 singing-clock` starts container
- [ ] `curl localhost:8081/api/status` returns JSON
- [ ] Dashboard loads at `http://localhost:8081`
- [ ] Local `python3 server.py` still binds to 127.0.0.1 by default
- [ ] `python3 server.py 9090` still works (port arg parsing)
- [ ] `python3 server.py --bind-all` binds to 0.0.0.0:8080
- [ ] All 185 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)