### PR TITLE
Add end-to-end test infrastructure - 53 integration tests

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -22,7 +22,7 @@ import sys
 import time
 import urllib.error
 import urllib.request
-from collections import Counter, defaultdict
+from collections import defaultdict
 from pathlib import Path
 
 # ─── Configuration ───────────────────────────────────────────────────────

--- a/scan.py
+++ b/scan.py
@@ -885,6 +885,154 @@ def fit_models(monthly_data, epoch_date):
     return models
 
 
+# ─── Aggregation Helpers ─────────────────────────────────────────────────
+
+def aggregate_repo_stats(scored_list, total_cap):
+    """Aggregate per-repo statistics from scored commits.
+
+    Returns a list of repo stat dicts sorted by capability (descending).
+    """
+    repo_data = defaultdict(lambda: {
+        "commits": 0, "capability": 0.0,
+        "min_date": None, "max_date": None, "cat_scores": defaultdict(float)
+    })
+    for date, total, cats, message, repo, _ in scored_list:
+        r = repo_data[repo]
+        r["commits"] += 1
+        r["capability"] += total
+        if r["min_date"] is None or date < r["min_date"]:
+            r["min_date"] = date
+        if r["max_date"] is None or date > r["max_date"]:
+            r["max_date"] = date
+        for cat, score in cats.items():
+            r["cat_scores"][cat] += score
+
+    # Disambiguate duplicate basenames
+    basenames = defaultdict(list)
+    for repo_path in repo_data:
+        basenames[Path(repo_path).name].append(repo_path)
+    display_names = {}
+    for name, paths in basenames.items():
+        if len(paths) == 1:
+            display_names[paths[0]] = name
+        else:
+            for p in paths:
+                parent = Path(p).parent.name
+                display_names[p] = f"{name} ({parent})"
+
+    result = []
+    for repo_path, r in repo_data.items():
+        top_cats = sorted(r["cat_scores"], key=r["cat_scores"].get, reverse=True)[:3]
+        pct = (r["capability"] / total_cap * 100) if total_cap else 0
+        result.append({
+            "name": display_names.get(repo_path, Path(repo_path).name),
+            "path": repo_path,
+            "commits": r["commits"],
+            "capability": round(r["capability"]),
+            "pct_contribution": round(pct, 1),
+            "first_activity": r["min_date"].isoformat() if r["min_date"] else None,
+            "last_activity": r["max_date"].isoformat() if r["max_date"] else None,
+            "top_categories": top_cats,
+        })
+    result.sort(key=lambda x: x["capability"], reverse=True)
+    return result
+
+
+def aggregate_monthly(scored_list, epoch_date, end_date, scored_regex=None):
+    """Aggregate scored commits into monthly data.
+
+    Returns (monthly_data, monthly_regex_data, category_monthly) where:
+    - monthly_data: list of month dicts with cumulative stats
+    - monthly_regex_data: list of month dicts for regex-only scoring (empty if scored_regex is None)
+    - category_monthly: dict mapping (year, month) → {category: score}
+    """
+    all_months = []
+    y, m = epoch_date.year, epoch_date.month
+    while (y, m) <= (end_date.year, end_date.month):
+        all_months.append((y, m))
+        m += 1
+        if m > 12:
+            m = 1
+            y += 1
+
+    monthly_commits = defaultdict(int)
+    monthly_capability = defaultdict(float)
+    monthly_cat_scores = defaultdict(lambda: defaultdict(float))
+
+    for date, total, cats, message, repo, _ in scored_list:
+        key = (date.year, date.month)
+        monthly_commits[key] += 1
+        monthly_capability[key] += total
+        for cat, score in cats.items():
+            monthly_cat_scores[key][cat] += score
+
+    # Also aggregate regex-only scores when provided
+    rx_monthly_capability = defaultdict(float)
+    rx_monthly_cat_scores = defaultdict(lambda: defaultdict(float))
+    if scored_regex is not None:
+        for date, total, cats, message, repo, _ in scored_regex:
+            key = (date.year, date.month)
+            rx_monthly_capability[key] += total
+            for cat, score in cats.items():
+                rx_monthly_cat_scores[key][cat] += score
+
+    cum_commits = 0
+    cum_capability = 0
+    rx_cum_capability = 0
+    monthly_data = []
+    monthly_regex_data = []
+
+    for ym in all_months:
+        c = monthly_commits.get(ym, 0)
+        cap = monthly_capability.get(ym, 0)
+        cum_commits += c
+        cum_capability += cap
+
+        cats = monthly_cat_scores.get(ym, {})
+        soph = compute_sophistication(cats)
+
+        monthly_data.append({
+            "month": f"{ym[0]}-{ym[1]:02d}",
+            "commits": c,
+            "capability": round(cap),
+            "sophistication": round(soph, 3),
+            "cumulative_commits": cum_commits,
+            "cumulative_capability": round(cum_capability),
+        })
+
+        # Build regex-only monthly data when enrichment is active
+        if scored_regex is not None:
+            rx_cap = rx_monthly_capability.get(ym, 0)
+            rx_cum_capability += rx_cap
+            rx_cats = rx_monthly_cat_scores.get(ym, {})
+            rx_soph = compute_sophistication(rx_cats)
+            monthly_regex_data.append({
+                "month": f"{ym[0]}-{ym[1]:02d}",
+                "commits": c,
+                "capability": round(rx_cap),
+                "sophistication": round(rx_soph, 3),
+                "cumulative_commits": cum_commits,
+                "cumulative_capability": round(rx_cum_capability),
+            })
+
+    # Smooth sophistication values with EMA
+    raw_soph = [m["sophistication"] for m in monthly_data]
+    smoothed = smooth_sophistication(raw_soph)
+    for i, m in enumerate(monthly_data):
+        m["sophistication"] = round(smoothed[i], 3)
+
+    if monthly_regex_data:
+        rx_raw_soph = [m["sophistication"] for m in monthly_regex_data]
+        rx_smoothed = smooth_sophistication(rx_raw_soph)
+        for i, m in enumerate(monthly_regex_data):
+            m["sophistication"] = round(rx_smoothed[i], 3)
+
+    # Build category_monthly for external use
+    category_monthly = dict(monthly_cat_scores)
+
+    return monthly_data, monthly_regex_data, category_monthly
+
+
 # ─── History Tracking ────────────────────────────────────────────────────
 
 def load_history():
@@ -1443,139 +1591,15 @@ def main(args=None):
     print(f"  {cache_hits} cached, {len(commits) - cache_hits} scored fresh")
 
     # Aggregate per-repo stats
-    def aggregate_repo_stats(scored_list, total_cap):
-        repo_data = defaultdict(lambda: {
-            "commits": 0, "capability": 0.0,
-            "min_date": None, "max_date": None, "cat_scores": defaultdict(float)
-        })
-        for date, total, cats, message, repo, _ in scored_list:
-            r = repo_data[repo]
-            r["commits"] += 1
-            r["capability"] += total
-            if r["min_date"] is None or date < r["min_date"]:
-                r["min_date"] = date
-            if r["max_date"] is None or date > r["max_date"]:
-                r["max_date"] = date
-            for cat, score in cats.items():
-                r["cat_scores"][cat] += score
-
-        # Disambiguate duplicate basenames
-        basenames = defaultdict(list)
-        for repo_path in repo_data:
-            basenames[Path(repo_path).name].append(repo_path)
-        display_names = {}
-        for name, paths in basenames.items():
-            if len(paths) == 1:
-                display_names[paths[0]] = name
-            else:
-                for p in paths:
-                    parent = Path(p).parent.name
-                    display_names[p] = f"{name} ({parent})"
-
-        result = []
-        for repo_path, r in repo_data.items():
-            top_cats = sorted(r["cat_scores"], key=r["cat_scores"].get, reverse=True)[:3]
-            pct = (r["capability"] / total_cap * 100) if total_cap else 0
-            result.append({
-                "name": display_names.get(repo_path, Path(repo_path).name),
-                "path": repo_path,
-                "commits": r["commits"],
-                "capability": round(r["capability"]),
-                "pct_contribution": round(pct, 1),
-                "first_activity": r["min_date"].isoformat() if r["min_date"] else None,
-                "last_activity": r["max_date"].isoformat() if r["max_date"] else None,
-                "top_categories": top_cats,
-            })
-        result.sort(key=lambda x: x["capability"], reverse=True)
-        return result
-
     total_capability_for_repos = sum(s[1] for s in scored)
     repo_stats = aggregate_repo_stats(scored, total_capability_for_repos)
 
     # Aggregate by month
     print("Aggregating by month...")
-    all_months = []
-    y, m = epoch_date.year, epoch_date.month
-    while (y, m) <= (today.year, today.month):
-        all_months.append((y, m))
-        m += 1
-        if m > 12:
-            m = 1
-            y += 1
-
-    monthly_commits = defaultdict(int)
-    monthly_capability = defaultdict(float)
-    monthly_cat_scores = defaultdict(lambda: defaultdict(float))
-    daily_counts = Counter()
-
-    for date, total, cats, message, repo, _ in scored:
-        key = (date.year, date.month)
-        monthly_commits[key] += 1
-        monthly_capability[key] += total
-        daily_counts[date] += 1
-        for cat, score in cats.items():
-            monthly_cat_scores[key][cat] += score
-
-    # Also aggregate regex-only scores when enrichment is active
-    rx_monthly_capability = defaultdict(float)
-    rx_monthly_cat_scores = defaultdict(lambda: defaultdict(float))
-    if enrich_cache is not None:
-        for date, total, cats, message, repo, _ in scored_regex:
-            key = (date.year, date.month)
-            rx_monthly_capability[key] += total
-            for cat, score in cats.items():
-                rx_monthly_cat_scores[key][cat] += score
-
-    cum_commits = 0
-    cum_capability = 0
-    rx_cum_capability = 0
-    monthly_data = []
-    monthly_regex_data = []
-
-    for ym in all_months:
-        c = monthly_commits.get(ym, 0)
-        cap = monthly_capability.get(ym, 0)
-        cum_commits += c
-        cum_capability += cap
-
-        cats = monthly_cat_scores.get(ym, {})
-        soph = compute_sophistication(cats)
-
-        monthly_data.append({
-            "month": f"{ym[0]}-{ym[1]:02d}",
-            "commits": c,
-            "capability": round(cap),
-            "sophistication": round(soph, 3),
-            "cumulative_commits": cum_commits,
-            "cumulative_capability": round(cum_capability),
-        })
-
-        # Build regex-only monthly data when enrichment is active
-        if enrich_cache is not None:
-            rx_cap = rx_monthly_capability.get(ym, 0)
-            rx_cum_capability += rx_cap
-            rx_cats = rx_monthly_cat_scores.get(ym, {})
-            rx_soph = compute_sophistication(rx_cats)
-            monthly_regex_data.append({
-                "month": f"{ym[0]}-{ym[1]:02d}",
-                "commits": c,
-                "capability": round(rx_cap),
-                "sophistication": round(rx_soph, 3),
-                "cumulative_commits": cum_commits,
-                "cumulative_capability": round(rx_cum_capability),
-            })
-
-    # Smooth sophistication values with EMA
-    raw_soph = [m["sophistication"] for m in monthly_data]
-    smoothed = smooth_sophistication(raw_soph)
-    for i, m in enumerate(monthly_data):
-        m["sophistication"] = round(smoothed[i], 3)
-
-    if monthly_regex_data:
-        rx_raw_soph = [m["sophistication"] for m in monthly_regex_data]
-        rx_smoothed = smooth_sophistication(rx_raw_soph)
-        for i, m in enumerate(monthly_regex_data):
-            m["sophistication"] = round(rx_smoothed[i], 3)
+    scored_regex_arg = scored_regex if enrich_cache is not None else None
+    monthly_data, monthly_regex_data, cat_monthly_raw = aggregate_monthly(
+        scored, epoch_date, today, scored_regex=scored_regex_arg
+    )
 
     # Aggregate by week
     print("Aggregating by week...")
@@ -1604,10 +1628,13 @@ def main(args=None):
 
     # Category breakdown by month
     category_monthly = {}
-    for ym in all_months:
+    for ym, cats in cat_monthly_raw.items():
         key = f"{ym[0]}-{ym[1]:02d}"
-        cats = monthly_cat_scores.get(ym, {})
         category_monthly[key] = {cat: round(cats.get(cat, 0)) for cat in CATEGORIES}
+    # Ensure all months in monthly_data have a category_monthly entry
+    for md in monthly_data:
+        if md["month"] not in category_monthly:
+            category_monthly[md["month"]] = {cat: 0 for cat in CATEGORIES}
 
     # Fit models
     print("\nFitting models...")
@@ -1620,7 +1647,7 @@ def main(args=None):
 
     current = {
         "total_commits": len(commits),
-        "total_capability": round(cum_capability),
+        "total_capability": monthly_data[-1]["cumulative_capability"] if monthly_data else 0,
         "pct_of_asymptote": pct_asymptote,
         "latest_commit_date": latest_date.isoformat(),
         "current_sophistication": current_soph,

--- a/tests/test_fit_models.py
+++ b/tests/test_fit_models.py
@@ -1,0 +1,296 @@
+"""Integration tests for fit_models() with synthetic data from known logistic parameters."""
+
+import datetime
+import math
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from scan import fit_models, logistic, logistic_deriv, linreg
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────
+
+def _logistic(t, L, r, t_mid):
+    """Pure logistic for generating synthetic data (no clamping)."""
+    return L / (1.0 + math.exp(-r * (t - t_mid)))
+
+
+def _make_monthly_data(n_months, commit_L, commit_r, commit_tmid,
+                       cap_L, cap_r, cap_tmid,
+                       soph_slope, soph_intercept,
+                       epoch_date=None):
+    """Generate synthetic monthly_data from known logistic/linear parameters.
+
+    All cumulative values follow logistic curves so fit_models() can recover
+    the original parameters. Sophistication follows a linear trend.
+    """
+    if epoch_date is None:
+        epoch_date = datetime.date(2025, 1, 1)
+
+    data = []
+    prev_cum_commits = 0
+    prev_cum_cap = 0
+
+    for t in range(n_months):
+        cum_commits = round(_logistic(t, commit_L, commit_r, commit_tmid))
+        cum_cap = round(_logistic(t, cap_L, cap_r, cap_tmid))
+
+        commits = max(0, cum_commits - prev_cum_commits)
+        cap = max(0, cum_cap - prev_cum_cap)
+
+        soph = max(0.0, min(1.0, soph_intercept + soph_slope * t))
+
+        month_date = epoch_date + datetime.timedelta(days=t * 30.44)
+        data.append({
+            "month": month_date.strftime("%Y-%m"),
+            "commits": commits,
+            "capability": cap,
+            "sophistication": round(soph, 3),
+            "cumulative_commits": cum_commits,
+            "cumulative_capability": cum_cap,
+        })
+
+        prev_cum_commits = cum_commits
+        prev_cum_cap = cum_cap
+
+    return data
+
+
+# Standard parameters chosen to fall on grid points
+EPOCH = datetime.date(2025, 1, 1)
+COMMIT_L, COMMIT_R, COMMIT_TMID = 100, 0.8, 4.0
+CAP_L, CAP_R, CAP_TMID = 250, 0.6, 4.0
+SOPH_SLOPE, SOPH_INTERCEPT = 0.05, 0.15
+
+
+def _standard_monthly_data(n_months=12):
+    return _make_monthly_data(
+        n_months, COMMIT_L, COMMIT_R, COMMIT_TMID,
+        CAP_L, CAP_R, CAP_TMID,
+        SOPH_SLOPE, SOPH_INTERCEPT, EPOCH,
+    )
+
+
+@patch("builtins.print")
+class TestFitModelsKeys(unittest.TestCase):
+    """Test that fit_models returns correctly structured output."""
+
+    def test_returns_all_model_keys(self, mock_print):
+        data = _standard_monthly_data()
+        models = fit_models(data, EPOCH)
+        for key in ("commit_rate", "capability", "sophistication", "convergence_date"):
+            self.assertIn(key, models, f"Missing key: {key}")
+
+    def test_commit_rate_has_expected_keys(self, mock_print):
+        data = _standard_monthly_data()
+        models = fit_models(data, EPOCH)
+        cr = models["commit_rate"]
+        for key in ("L", "r", "t_mid", "r_squared", "zero_date", "projection"):
+            self.assertIn(key, cr, f"commit_rate missing: {key}")
+
+    def test_capability_has_expected_keys(self, mock_print):
+        data = _standard_monthly_data()
+        models = fit_models(data, EPOCH)
+        cap = models["capability"]
+        for key in ("L", "r", "t_mid", "r_squared", "pct_95_date",
+                     "pct_99_date", "pct_now", "projection"):
+            self.assertIn(key, cap, f"capability missing: {key}")
+
+    def test_sophistication_has_expected_keys(self, mock_print):
+        data = _standard_monthly_data()
+        models = fit_models(data, EPOCH)
+        soph = models["sophistication"]
+        for key in ("slope", "intercept", "pct_100_date"):
+            self.assertIn(key, soph, f"sophistication missing: {key}")
+
+
+@patch("builtins.print")
+class TestFitModelsCommitRate(unittest.TestCase):
+    """Test commit rate model recovery from clean logistic data."""
+
+    def test_r_squared_high(self, mock_print):
+        data = _standard_monthly_data()
+        models = fit_models(data, EPOCH)
+        self.assertGreater(models["commit_rate"]["r_squared"], 0.90)
+
+    def test_L_recoverable(self, mock_print):
+        data = _standard_monthly_data()
+        models = fit_models(data, EPOCH)
+        recovered_L = models["commit_rate"]["L"]
+        self.assertAlmostEqual(recovered_L, COMMIT_L, delta=COMMIT_L * 0.3,
+                               msg=f"L={recovered_L}, expected ~{COMMIT_L}")
+
+    def test_zero_date_exists(self, mock_print):
+        data = _standard_monthly_data()
+        models = fit_models(data, EPOCH)
+        zd = models["commit_rate"]["zero_date"]
+        self.assertIsNotNone(zd)
+        datetime.date.fromisoformat(zd)  # Should not raise
+
+    def test_projection_12_months(self, mock_print):
+        data = _standard_monthly_data()
+        models = fit_models(data, EPOCH)
+        self.assertEqual(len(models["commit_rate"]["projection"]), 12)
+
+    def test_projection_months_after_data(self, mock_print):
+        data = _standard_monthly_data()
+        models = fit_models(data, EPOCH)
+        last_data_month = data[-1]["month"]
+        first_proj_month = models["commit_rate"]["projection"][0]["month"]
+        self.assertGreater(first_proj_month, last_data_month)
+
+
+@patch("builtins.print")
+class TestFitModelsCapability(unittest.TestCase):
+    """Test capability model recovery."""
+
+    def test_r_squared_high(self, mock_print):
+        data = _standard_monthly_data()
+        models = fit_models(data, EPOCH)
+        self.assertGreater(models["capability"]["r_squared"], 0.90)
+
+    def test_milestones_ordered(self, mock_print):
+        data = _standard_monthly_data()
+        models = fit_models(data, EPOCH)
+        d95 = models["capability"]["pct_95_date"]
+        d99 = models["capability"]["pct_99_date"]
+        self.assertLess(d95, d99)
+
+    def test_pct_now_reasonable(self, mock_print):
+        data = _standard_monthly_data()
+        models = fit_models(data, EPOCH)
+        pct = models["capability"]["pct_now"]
+        self.assertGreater(pct, 30)
+        self.assertLessEqual(pct, 100)
+
+    def test_projection_has_pct(self, mock_print):
+        data = _standard_monthly_data()
+        models = fit_models(data, EPOCH)
+        for entry in models["capability"]["projection"]:
+            self.assertIn("pct_of_L", entry)
+            self.assertIn("predicted_capability", entry)
+
+
+@patch("builtins.print")
+class TestFitModelsSophistication(unittest.TestCase):
+    """Test sophistication linear model."""
+
+    def test_slope_positive(self, mock_print):
+        data = _standard_monthly_data()
+        models = fit_models(data, EPOCH)
+        self.assertGreater(models["sophistication"]["slope"], 0)
+
+    def test_pct100_date_valid(self, mock_print):
+        data = _standard_monthly_data()
+        models = fit_models(data, EPOCH)
+        d = models["sophistication"]["pct_100_date"]
+        datetime.date.fromisoformat(d)  # Should not raise
+
+    def test_pct100_hand_calculated(self, mock_print):
+        """Verify pct_100_date matches hand calculation within 45 days."""
+        data = _standard_monthly_data()
+        models = fit_models(data, EPOCH)
+
+        # Hand-calculate: the sophistication data in monthly_data is
+        # soph_intercept + soph_slope * t, so linreg should recover these.
+        # pct100_t = (1.0 - intercept) / slope
+        intercept = models["sophistication"]["intercept"]
+        slope = models["sophistication"]["slope"]
+        expected_t = (1.0 - intercept) / slope
+        expected_date = EPOCH + datetime.timedelta(days=expected_t * 30.44)
+        actual_date = datetime.date.fromisoformat(models["sophistication"]["pct_100_date"])
+        delta = abs((actual_date - expected_date).days)
+        self.assertLessEqual(delta, 45, f"pct_100_date off by {delta} days")
+
+
+@patch("builtins.print")
+class TestFitModelsConvergence(unittest.TestCase):
+    """Test convergence date calculation."""
+
+    def test_convergence_date_is_component_average(self, mock_print):
+        data = _standard_monthly_data()
+        models = fit_models(data, EPOCH)
+
+        dates = []
+        if models["commit_rate"]["zero_date"]:
+            dates.append(datetime.date.fromisoformat(models["commit_rate"]["zero_date"]))
+        dates.append(datetime.date.fromisoformat(models["capability"]["pct_95_date"]))
+        dates.append(datetime.date.fromisoformat(models["capability"]["pct_99_date"]))
+        dates.append(datetime.date.fromisoformat(models["sophistication"]["pct_100_date"]))
+
+        expected_ord = sum(d.toordinal() for d in dates) // len(dates)
+        expected = datetime.date.fromordinal(expected_ord)
+        actual = datetime.date.fromisoformat(models["convergence_date"])
+        self.assertEqual(actual, expected)
+
+    def test_convergence_date_after_epoch(self, mock_print):
+        data = _standard_monthly_data()
+        models = fit_models(data, EPOCH)
+        conv = datetime.date.fromisoformat(models["convergence_date"])
+        self.assertGreater(conv, EPOCH)
+
+
+@patch("builtins.print")
+class TestFitModelsEdgeCases(unittest.TestCase):
+    """Test edge cases and degenerate inputs."""
+
+    def test_empty_monthly_data(self, mock_print):
+        models = fit_models([], EPOCH)
+        self.assertEqual(models, {})
+
+    def test_single_month(self, mock_print):
+        data = _standard_monthly_data(n_months=1)
+        models = fit_models(data, EPOCH)
+        # Should not crash; may produce partial or empty models
+        self.assertIsInstance(models, dict)
+
+    def test_three_months_minimal(self, mock_print):
+        data = _standard_monthly_data(n_months=3)
+        models = fit_models(data, EPOCH)
+        self.assertIsInstance(models, dict)
+
+    def test_flat_commits(self, mock_print):
+        """Constant cumulative commits should produce poor fit or degenerate."""
+        data = []
+        for t in range(12):
+            month_date = EPOCH + datetime.timedelta(days=t * 30.44)
+            data.append({
+                "month": month_date.strftime("%Y-%m"),
+                "commits": 0 if t > 0 else 10,
+                "capability": 0 if t > 0 else 50,
+                "sophistication": 0.5,
+                "cumulative_commits": 10,
+                "cumulative_capability": 50,
+            })
+        models = fit_models(data, EPOCH)
+        # With flat cumulative data, R² should be low or model may not fit well
+        if "commit_rate" in models:
+            # Any R² is acceptable; just shouldn't crash
+            self.assertIsInstance(models["commit_rate"]["r_squared"], (int, float))
+
+    def test_all_dates_iso_format(self, mock_print):
+        data = _standard_monthly_data()
+        models = fit_models(data, EPOCH)
+
+        # Check all date-like string values parse as ISO dates
+        date_keys = {
+            ("commit_rate", "zero_date"),
+            ("capability", "pct_95_date"),
+            ("capability", "pct_99_date"),
+            ("sophistication", "pct_100_date"),
+        }
+        for section, key in date_keys:
+            if section in models:
+                val = models[section][key]
+                if val is not None:
+                    datetime.date.fromisoformat(val)
+
+        if "convergence_date" in models:
+            datetime.date.fromisoformat(models["convergence_date"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fit_models.py
+++ b/tests/test_fit_models.py
@@ -120,7 +120,7 @@ class TestFitModelsCommitRate(unittest.TestCase):
         data = _standard_monthly_data()
         models = fit_models(data, EPOCH)
         recovered_L = models["commit_rate"]["L"]
-        self.assertAlmostEqual(recovered_L, COMMIT_L, delta=COMMIT_L * 0.3,
+        self.assertAlmostEqual(recovered_L, COMMIT_L, delta=COMMIT_L * 0.15,
                                msg=f"L={recovered_L}, expected ~{COMMIT_L}")
 
     def test_zero_date_exists(self, mock_print):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,412 @@
+"""Integration tests for aggregate_monthly(), aggregate_repo_stats(), and end-to-end pipeline."""
+
+import datetime
+import math
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from scan import (
+    aggregate_monthly, aggregate_repo_stats, fit_models,
+    compute_sophistication, smooth_sophistication, logistic, CATEGORIES,
+)
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────
+
+EPOCH = datetime.date(2025, 1, 1)
+
+
+def _make_scored(date, total, cats, repo="repo-a", message="test commit",
+                 hash_id="abc123"):
+    """Build a scored commit tuple: (date, total, cats, message, repo, hash_id)."""
+    return (date, total, cats, message, repo, hash_id)
+
+
+def _logistic(t, L, r, t_mid):
+    return L / (1.0 + math.exp(-r * (t - t_mid)))
+
+
+# ─── TestAggregateMonthly ────────────────────────────────────────────────
+
+class TestAggregateMonthly(unittest.TestCase):
+    """Test the extracted aggregate_monthly() function."""
+
+    def test_single_commit_one_month(self):
+        scored = [_make_scored(datetime.date(2025, 1, 15), 10.0,
+                               {"foundation": 5, "agents": 5})]
+        end = datetime.date(2025, 1, 31)
+        monthly, _, _ = aggregate_monthly(scored, EPOCH, end)
+        self.assertEqual(len(monthly), 1)
+        self.assertEqual(monthly[0]["commits"], 1)
+        self.assertEqual(monthly[0]["cumulative_commits"], 1)
+        self.assertEqual(monthly[0]["cumulative_capability"], 10)
+
+    def test_two_commits_same_month_sum(self):
+        scored = [
+            _make_scored(datetime.date(2025, 1, 10), 10.0,
+                         {"foundation": 5, "agents": 5}, hash_id="a1"),
+            _make_scored(datetime.date(2025, 1, 20), 15.0,
+                         {"foundation": 8, "agents": 7}, hash_id="a2"),
+        ]
+        end = datetime.date(2025, 1, 31)
+        monthly, _, _ = aggregate_monthly(scored, EPOCH, end)
+        self.assertEqual(monthly[0]["commits"], 2)
+        self.assertEqual(monthly[0]["cumulative_capability"], 25)
+
+    def test_cumulative_commits_monotonic(self):
+        scored = [
+            _make_scored(datetime.date(2025, 1, 10), 5.0, {"foundation": 5},
+                         hash_id="a1"),
+            _make_scored(datetime.date(2025, 2, 10), 8.0, {"agents": 8},
+                         hash_id="a2"),
+            _make_scored(datetime.date(2025, 3, 10), 3.0, {"meta": 3},
+                         hash_id="a3"),
+        ]
+        end = datetime.date(2025, 3, 31)
+        monthly, _, _ = aggregate_monthly(scored, EPOCH, end)
+        prev = 0
+        for m in monthly:
+            self.assertGreaterEqual(m["cumulative_commits"], prev)
+            prev = m["cumulative_commits"]
+
+    def test_cumulative_capability_monotonic(self):
+        scored = [
+            _make_scored(datetime.date(2025, 1, 10), 5.0, {"foundation": 5},
+                         hash_id="a1"),
+            _make_scored(datetime.date(2025, 2, 10), 8.0, {"agents": 8},
+                         hash_id="a2"),
+        ]
+        end = datetime.date(2025, 2, 28)
+        monthly, _, _ = aggregate_monthly(scored, EPOCH, end)
+        prev = 0
+        for m in monthly:
+            self.assertGreaterEqual(m["cumulative_capability"], prev)
+            prev = m["cumulative_capability"]
+
+    def test_empty_months_filled(self):
+        """Months between epoch and first commit should have 0 commits."""
+        scored = [_make_scored(datetime.date(2025, 3, 10), 10.0, {"agents": 10})]
+        end = datetime.date(2025, 3, 31)
+        monthly, _, _ = aggregate_monthly(scored, EPOCH, end)
+        self.assertEqual(len(monthly), 3)
+        self.assertEqual(monthly[0]["commits"], 0)
+        self.assertEqual(monthly[1]["commits"], 0)
+        self.assertEqual(monthly[2]["commits"], 1)
+
+    def test_month_format(self):
+        scored = [_make_scored(datetime.date(2025, 1, 15), 10.0, {"foundation": 10})]
+        end = datetime.date(2025, 3, 31)
+        monthly, _, _ = aggregate_monthly(scored, EPOCH, end)
+        import re
+        for m in monthly:
+            self.assertRegex(m["month"], r"^\d{4}-\d{2}$")
+
+    def test_capability_rounded(self):
+        scored = [_make_scored(datetime.date(2025, 1, 15), 10.7, {"foundation": 10.7})]
+        end = datetime.date(2025, 1, 31)
+        monthly, _, _ = aggregate_monthly(scored, EPOCH, end)
+        self.assertIsInstance(monthly[0]["capability"], int)
+        self.assertIsInstance(monthly[0]["cumulative_capability"], int)
+
+    def test_sophistication_bounded(self):
+        scored = [
+            _make_scored(datetime.date(2025, 1, 10), 5.0, {"foundation": 5},
+                         hash_id="a1"),
+            _make_scored(datetime.date(2025, 2, 10), 8.0, {"agents": 8},
+                         hash_id="a2"),
+            _make_scored(datetime.date(2025, 3, 10), 3.0, {"meta": 3},
+                         hash_id="a3"),
+        ]
+        end = datetime.date(2025, 3, 31)
+        monthly, _, _ = aggregate_monthly(scored, EPOCH, end)
+        for m in monthly:
+            self.assertGreaterEqual(m["sophistication"], 0)
+            self.assertLessEqual(m["sophistication"], 1)
+
+    def test_sophistication_ema_applied(self):
+        """EMA smoothing should make values differ from raw compute_sophistication()."""
+        scored = [
+            _make_scored(datetime.date(2025, 1, 10), 5.0,
+                         {"foundation": 5, "agents": 0}, hash_id="a1"),
+            _make_scored(datetime.date(2025, 2, 10), 8.0,
+                         {"agents": 8, "meta": 8}, hash_id="a2"),
+        ]
+        end = datetime.date(2025, 2, 28)
+        monthly, _, _ = aggregate_monthly(scored, EPOCH, end)
+
+        # Compute raw sophistication for month 2
+        raw_soph_m2 = compute_sophistication({"agents": 8, "meta": 8})
+        # After EMA, month 2 should differ from raw (unless alpha=1)
+        if raw_soph_m2 > 0:
+            # The smoothed value blends with month 1, so it won't equal raw
+            raw_soph_m1 = compute_sophistication({"foundation": 5, "agents": 0})
+            if abs(raw_soph_m1 - raw_soph_m2) > 0.01:
+                self.assertNotAlmostEqual(monthly[1]["sophistication"],
+                                          round(raw_soph_m2, 3), places=3)
+
+    def test_multi_repo_merged_into_months(self):
+        scored = [
+            _make_scored(datetime.date(2025, 1, 10), 5.0, {"foundation": 5},
+                         repo="repo-a", hash_id="a1"),
+            _make_scored(datetime.date(2025, 1, 20), 10.0, {"agents": 10},
+                         repo="repo-b", hash_id="b1"),
+        ]
+        end = datetime.date(2025, 1, 31)
+        monthly, _, _ = aggregate_monthly(scored, EPOCH, end)
+        self.assertEqual(monthly[0]["commits"], 2)
+        self.assertEqual(monthly[0]["cumulative_capability"], 15)
+
+    def test_category_monthly_populated(self):
+        scored = [_make_scored(datetime.date(2025, 1, 15), 10.0,
+                               {"foundation": 4, "agents": 6})]
+        end = datetime.date(2025, 1, 31)
+        _, _, cat_monthly = aggregate_monthly(scored, EPOCH, end)
+        key = (2025, 1)
+        self.assertIn(key, cat_monthly)
+        self.assertEqual(cat_monthly[key]["foundation"], 4)
+        self.assertEqual(cat_monthly[key]["agents"], 6)
+
+    def test_dual_scoring_regex_data(self):
+        scored = [_make_scored(datetime.date(2025, 1, 15), 10.0, {"agents": 10})]
+        scored_regex = [_make_scored(datetime.date(2025, 1, 15), 5.0,
+                                     {"foundation": 5})]
+        end = datetime.date(2025, 1, 31)
+        monthly, regex_monthly, _ = aggregate_monthly(
+            scored, EPOCH, end, scored_regex=scored_regex
+        )
+        self.assertEqual(len(regex_monthly), 1)
+        self.assertEqual(regex_monthly[0]["cumulative_capability"], 5)
+        self.assertEqual(monthly[0]["cumulative_capability"], 10)
+
+
+# ─── TestAggregateRepoStats ──────────────────────────────────────────────
+
+class TestAggregateRepoStats(unittest.TestCase):
+    """Test the extracted aggregate_repo_stats() function."""
+
+    def test_single_repo(self):
+        scored = [
+            _make_scored(datetime.date(2025, 1, 10), 10.0, {"foundation": 10},
+                         repo="/path/to/repo-a", hash_id="a1"),
+            _make_scored(datetime.date(2025, 2, 10), 15.0, {"agents": 15},
+                         repo="/path/to/repo-a", hash_id="a2"),
+        ]
+        result = aggregate_repo_stats(scored, 25.0)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["commits"], 2)
+        self.assertEqual(result[0]["capability"], 25)
+
+    def test_multi_repo_sorted_by_capability(self):
+        scored = [
+            _make_scored(datetime.date(2025, 1, 10), 5.0, {"foundation": 5},
+                         repo="/path/to/small", hash_id="s1"),
+            _make_scored(datetime.date(2025, 1, 10), 20.0, {"agents": 20},
+                         repo="/path/to/big", hash_id="b1"),
+        ]
+        result = aggregate_repo_stats(scored, 25.0)
+        self.assertEqual(len(result), 2)
+        self.assertGreater(result[0]["capability"], result[1]["capability"])
+
+    def test_pct_contribution_sums_near_100(self):
+        scored = [
+            _make_scored(datetime.date(2025, 1, 10), 30.0, {"foundation": 30},
+                         repo="/path/to/a", hash_id="a1"),
+            _make_scored(datetime.date(2025, 1, 10), 70.0, {"agents": 70},
+                         repo="/path/to/b", hash_id="b1"),
+        ]
+        result = aggregate_repo_stats(scored, 100.0)
+        total_pct = sum(r["pct_contribution"] for r in result)
+        self.assertAlmostEqual(total_pct, 100.0, places=0)
+
+    def test_top_categories_max_3(self):
+        cats = {c: 1.0 for c in list(CATEGORIES.keys())[:5]}
+        scored = [_make_scored(datetime.date(2025, 1, 10), 5.0, cats,
+                               repo="/path/to/repo")]
+        result = aggregate_repo_stats(scored, 5.0)
+        self.assertLessEqual(len(result[0]["top_categories"]), 3)
+
+    def test_top_categories_sorted(self):
+        scored = [_make_scored(datetime.date(2025, 1, 10), 15.0,
+                               {"foundation": 1, "agents": 10, "meta": 4},
+                               repo="/path/to/repo")]
+        result = aggregate_repo_stats(scored, 15.0)
+        tops = result[0]["top_categories"]
+        self.assertEqual(tops[0], "agents")
+        self.assertEqual(tops[1], "meta")
+        self.assertEqual(tops[2], "foundation")
+
+    def test_date_range(self):
+        scored = [
+            _make_scored(datetime.date(2025, 1, 10), 5.0, {"foundation": 5},
+                         repo="/path/to/repo", hash_id="a1"),
+            _make_scored(datetime.date(2025, 3, 20), 5.0, {"agents": 5},
+                         repo="/path/to/repo", hash_id="a2"),
+        ]
+        result = aggregate_repo_stats(scored, 10.0)
+        self.assertLessEqual(result[0]["first_activity"],
+                             result[0]["last_activity"])
+
+    def test_capability_rounded(self):
+        scored = [_make_scored(datetime.date(2025, 1, 10), 10.7,
+                               {"foundation": 10.7}, repo="/path/to/repo")]
+        result = aggregate_repo_stats(scored, 10.7)
+        self.assertIsInstance(result[0]["capability"], int)
+
+    def test_duplicate_basename_disambiguated(self):
+        scored = [
+            _make_scored(datetime.date(2025, 1, 10), 5.0, {"foundation": 5},
+                         repo="/parent1/foo", hash_id="a1"),
+            _make_scored(datetime.date(2025, 1, 10), 5.0, {"agents": 5},
+                         repo="/parent2/foo", hash_id="b1"),
+        ]
+        result = aggregate_repo_stats(scored, 10.0)
+        names = [r["name"] for r in result]
+        self.assertEqual(len(set(names)), 2, "Names should be unique")
+        # Both should contain "foo" and a parent disambiguator
+        for name in names:
+            self.assertIn("foo", name)
+
+    def test_empty_scored_list(self):
+        result = aggregate_repo_stats([], 100.0)
+        self.assertEqual(result, [])
+
+    def test_zero_total_cap(self):
+        scored = [_make_scored(datetime.date(2025, 1, 10), 0.0, {},
+                               repo="/path/to/repo")]
+        result = aggregate_repo_stats(scored, 0)
+        self.assertEqual(result[0]["pct_contribution"], 0)
+
+
+# ─── TestEndToEnd ────────────────────────────────────────────────────────
+
+class TestEndToEnd(unittest.TestCase):
+    """Full pipeline: scored commits → aggregate_monthly → fit_models."""
+
+    @staticmethod
+    def _make_pipeline_data(n_months=12, cap_multiplier=1.0):
+        """Generate scored commits that produce nice logistic curves."""
+        scored = []
+        for t in range(n_months):
+            month_date = EPOCH + datetime.timedelta(days=t * 30.44)
+            commit_date = month_date + datetime.timedelta(days=5)
+
+            # Number of commits per month following rough logistic growth
+            n_commits = max(1, round(5 + 10 / (1 + math.exp(-0.5 * (t - 4)))))
+            for i in range(n_commits):
+                d = commit_date + datetime.timedelta(days=i)
+                # Mix of categories for realistic sophistication
+                if t < 4:
+                    cats = {"foundation": 3 * cap_multiplier,
+                            "elements": 2 * cap_multiplier}
+                else:
+                    cats = {"agents": 4 * cap_multiplier,
+                            "meta": 3 * cap_multiplier,
+                            "self_modify": 2 * cap_multiplier}
+                total = sum(cats.values())
+                scored.append(_make_scored(d, total, cats,
+                                           hash_id=f"h{t}-{i}"))
+        return scored
+
+    @patch("builtins.print")
+    def test_full_pipeline_produces_convergence(self, mock_print):
+        scored = self._make_pipeline_data()
+        end = EPOCH + datetime.timedelta(days=12 * 30.44)
+        monthly, _, _ = aggregate_monthly(scored, EPOCH, end)
+        models = fit_models(monthly, EPOCH)
+        self.assertIn("convergence_date", models)
+
+    @patch("builtins.print")
+    def test_pipeline_deterministic(self, mock_print):
+        scored = self._make_pipeline_data()
+        end = EPOCH + datetime.timedelta(days=12 * 30.44)
+
+        monthly1, _, _ = aggregate_monthly(scored, EPOCH, end)
+        models1 = fit_models(monthly1, EPOCH)
+
+        monthly2, _, _ = aggregate_monthly(scored, EPOCH, end)
+        models2 = fit_models(monthly2, EPOCH)
+
+        self.assertEqual(models1, models2)
+
+    @patch("builtins.print")
+    def test_monthly_keys_complete(self, mock_print):
+        scored = self._make_pipeline_data()
+        end = EPOCH + datetime.timedelta(days=12 * 30.44)
+        monthly, _, _ = aggregate_monthly(scored, EPOCH, end)
+        required = {"month", "commits", "capability", "sophistication",
+                     "cumulative_commits", "cumulative_capability"}
+        for m in monthly:
+            self.assertEqual(set(m.keys()), required)
+
+    @patch("builtins.print")
+    def test_models_keys_complete(self, mock_print):
+        scored = self._make_pipeline_data()
+        end = EPOCH + datetime.timedelta(days=12 * 30.44)
+        monthly, _, _ = aggregate_monthly(scored, EPOCH, end)
+        models = fit_models(monthly, EPOCH)
+        for key in ("commit_rate", "capability", "sophistication",
+                     "convergence_date"):
+            self.assertIn(key, models)
+
+    @patch("builtins.print")
+    def test_capability_model_keys(self, mock_print):
+        scored = self._make_pipeline_data()
+        end = EPOCH + datetime.timedelta(days=12 * 30.44)
+        monthly, _, _ = aggregate_monthly(scored, EPOCH, end)
+        models = fit_models(monthly, EPOCH)
+        cap = models["capability"]
+        for key in ("L", "r", "t_mid", "r_squared", "pct_95_date",
+                     "pct_99_date", "pct_now", "projection"):
+            self.assertIn(key, cap)
+
+    @patch("builtins.print")
+    def test_commit_rate_model_keys(self, mock_print):
+        scored = self._make_pipeline_data()
+        end = EPOCH + datetime.timedelta(days=12 * 30.44)
+        monthly, _, _ = aggregate_monthly(scored, EPOCH, end)
+        models = fit_models(monthly, EPOCH)
+        cr = models["commit_rate"]
+        for key in ("L", "r", "t_mid", "r_squared", "zero_date", "projection"):
+            self.assertIn(key, cr)
+
+    @patch("builtins.print")
+    def test_projection_entry_keys(self, mock_print):
+        scored = self._make_pipeline_data()
+        end = EPOCH + datetime.timedelta(days=12 * 30.44)
+        monthly, _, _ = aggregate_monthly(scored, EPOCH, end)
+        models = fit_models(monthly, EPOCH)
+
+        for entry in models["commit_rate"]["projection"]:
+            self.assertIn("month", entry)
+            self.assertIn("predicted_commits", entry)
+
+        for entry in models["capability"]["projection"]:
+            self.assertIn("month", entry)
+            self.assertIn("predicted_capability", entry)
+            self.assertIn("pct_of_L", entry)
+
+    @patch("builtins.print")
+    def test_more_advanced_commits_earlier_convergence(self, mock_print):
+        """Higher-weight commits should produce an earlier convergence date."""
+        scored_low = self._make_pipeline_data(cap_multiplier=1.0)
+        scored_high = self._make_pipeline_data(cap_multiplier=3.0)
+        end = EPOCH + datetime.timedelta(days=12 * 30.44)
+
+        monthly_low, _, _ = aggregate_monthly(scored_low, EPOCH, end)
+        monthly_high, _, _ = aggregate_monthly(scored_high, EPOCH, end)
+
+        models_low = fit_models(monthly_low, EPOCH)
+        models_high = fit_models(monthly_high, EPOCH)
+
+        if "convergence_date" in models_low and "convergence_date" in models_high:
+            conv_low = datetime.date.fromisoformat(models_low["convergence_date"])
+            conv_high = datetime.date.fromisoformat(models_high["convergence_date"])
+            # Higher capability should converge no later
+            self.assertLessEqual(conv_high, conv_low)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Extract `aggregate_repo_stats()` and `aggregate_monthly()` from `main()` to module level in `scan.py` for testability
- Add `tests/test_fit_models.py` (23 tests): validates `fit_models()` with synthetic logistic data — model key structure, parameter recovery, convergence date averaging, edge cases
- Add `tests/test_pipeline.py` (30 tests): validates monthly aggregation, repo stats, and full end-to-end pipeline including determinism and convergence behavior
- Total test count: 185 → 238

## Test plan
- [x] All 238 tests pass
- [x] All 185 existing tests still pass (no regressions from extraction)
- [x] New tests run in ~13s (grid search in fit_models dominates)
- [ ] Review synthetic data parameters for realism

🤖 Generated with [Claude Code](https://claude.com/claude-code)